### PR TITLE
create method to order node connections by connection latency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 /derby.log
 /out
 /config.txt
+/.classpath*
+/.project*
+/.settings*
+/.settings/org.eclipse.jdt.ui.prefs
+/.settings/org.eclipse.m2e.core.prefs

--- a/test/graphenej/api/NodeConnectionTest.java
+++ b/test/graphenej/api/NodeConnectionTest.java
@@ -119,6 +119,40 @@ public class NodeConnectionTest {
     }
     
     @Test
+    public void testSortedByLatencyNodeConnection() {
+        System.out.println("** Testing simple node connection order by latency test**");
+        nodeConnection = NodeConnection.getInstance();
+        nodeConnection.addNodeUrl(NODE_URL_1);
+        nodeConnection.addNodeUrl(NODE_URL_2);
+        nodeConnection.addNodeUrl(NODE_URL_5);
+        
+        // bitshare top node list 
+        nodeConnection.addNodeUrl("wss://eu.openledger.info/ws");
+        nodeConnection.addNodeUrl("wss://bitshares.crypto.fans/ws");
+        nodeConnection.addNodeUrl("wss://openledger.hk/ws");
+        nodeConnection.addNodeUrl("wss://api.bitshares.bhuz.info/ws");
+        nodeConnection.addNodeUrl("wss://ws.gdex.top");
+        
+        // TODO add more nodes to test
+        nodeConnection.orderNodeListBylatency();
+        
+        nodeConnection.connect("", "", true, mErrorListener);
+        
+        Timer timer = new Timer();
+        timer.schedule(getAccountsTask, 5000);
+        timer.schedule(releaseTask, 30000);
+        
+        try {
+            // Holding this thread while we get update notifications
+            synchronized (this) {
+                wait();
+            }
+        } catch (InterruptedException e) {
+            System.out.println("InterruptedException. Msg: " + e.getMessage());
+        }
+    }
+    
+    @Test
     public void testWrongUrl() {
         System.out.println("** Testing simple node connection with wrong URL **");
         nodeConnection = NodeConnection.getInstance();


### PR DESCRIPTION
https://trello.com/c/FcNSV9ob/16-created-wss-connection-manager

Simple latency test "whether that address is reachable. Best effort is made by the implementation to try to reach the host, but firewalls and server configuration may block requests resulting in a unreachable status while some specific ports may be accessible. A typical implementation will use ICMP ECHO REQUESTs if the privilege can be obtained, otherwise it will try to establish a TCP connection on port 7 (Echo) of the destination host."
node setup instruction should mention to open port 7

also,
-> Junit test created to the implemented function.
-> added version 2.15 on pom to jersey-container-servlet-core, jersey-media-moxy and jersey-spring3 for pass autobuild erros on eclipse.
-> added eclipse configuration to git ignore